### PR TITLE
Fix column quoting for postgres

### DIFF
--- a/twistar/dbconfig/postgres.py
+++ b/twistar/dbconfig/postgres.py
@@ -13,14 +13,10 @@ class PostgreSQLDBConfig(InteractionBase):
 
     def insertArgsToString(self, vals):
         if len(vals) > 0:
-            return "(" + ",".join(["%s" for _ in vals.items()]) + ")"            
+            return "(" + ",".join(["%s" for _ in vals.items()]) + ")"
         return "DEFAULT VALUES"
-            
-
-    
 
 
+    def escapeColNames(self, colnames):
+        return map(lambda x: '"%s"' % x, colnames)
 
-
-
-        


### PR DESCRIPTION
This patch adds an escapeColNames method to the postgres db config.
