### PR TITLE
error when clearing jointable for dict-configured habtm relationships

### DIFF
--- a/twistar/dbobject.py
+++ b/twistar/dbobject.py
@@ -261,6 +261,16 @@ class DBObject(Validator):
 
         @return: A C{Deferred}.        
         """        
+        def clearHabtmRelations():
+            deferreds = []
+            for relation in self.HABTM:
+                if isinstance(relation, dict):
+                    name = relation['name']
+                else:
+                    name = relation
+                d = getattr(self, name).clear()
+                deferreds.append(d)
+            return deferreds
 
         def _delete(result):
             oldid = self.id
@@ -272,7 +282,7 @@ class DBObject(Validator):
             if result == False:
                 return defer.succeed(self)
             else:
-                ds = [getattr(self, relation).clear() for relation in self.HABTM]
+                ds = clearHabtmRelations()
                 return defer.DeferredList(ds).addCallback(_delete)
 
         return defer.maybeDeferred(self.beforeDelete).addCallback(_deleteOnSuccess)

--- a/twistar/tests/mysql_config.py
+++ b/twistar/tests/mysql_config.py
@@ -21,6 +21,11 @@ def initDB(testKlass):
         txn.execute("""CREATE TABLE girls (id INT AUTO_INCREMENT, `name` VARCHAR(255), PRIMARY KEY (id))""")
         txn.execute("""CREATE TABLE nicknames (id INT AUTO_INCREMENT, `value` VARCHAR(255), `nicknameable_id` INT,
                        `nicknameable_type` VARCHAR(255), PRIMARY KEY(id))""")
+        txn.execute("""CREATE TABLE blogposts (id INT AUTO_INCREMENT,
+                       title VARCHAR(255), text VARCHAR(255), PRIMARY KEY (id))""")
+        txn.execute("""CREATE TABLE categories (id INT AUTO_INCREMENT,
+                       name VARCHAR(255), PRIMARY KEY (id))""")
+        txn.execute("""CREATE TABLE posts_categories (category_id INT, blogpost_id INT)""")
 
     return CONNECTION.runInteraction(runInitTxn)
 

--- a/twistar/tests/postgres_config.py
+++ b/twistar/tests/postgres_config.py
@@ -21,6 +21,11 @@ def initDB(testKlass):
         txn.execute("""CREATE TABLE girls (id SERIAL PRIMARY KEY, "name" VARCHAR(255))""")
         txn.execute("""CREATE TABLE nicknames (id SERIAL PRIMARY KEY, "value" VARCHAR(255), "nicknameable_id" INT,
                        "nicknameable_type" VARCHAR(255))""")
+        txn.execute("""CREATE TABLE blogposts (id SERIAL PRIMARY KEY,
+                       title VARCHAR(255), text VARCHAR(255))""")
+        txn.execute("""CREATE TABLE categories (id SERIAL PRIMARY KEY,
+                       name VARCHAR(255))""")
+        txn.execute("""CREATE TABLE posts_categories (category_id INT, blogpost_id INT)""")
 
     return CONNECTION.runInteraction(runInitTxn)
 

--- a/twistar/tests/sqlite_config.py
+++ b/twistar/tests/sqlite_config.py
@@ -21,6 +21,11 @@ def initDB(testKlass):
         txn.execute("""CREATE TABLE girls (id INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT)""")        
         txn.execute("""CREATE TABLE nicknames (id INTEGER PRIMARY KEY AUTOINCREMENT, `value` TEXT, `nicknameable_id` INTEGER,
                        `nicknameable_type` TEXT)""")
+        txn.execute("""CREATE TABLE blogposts (id INTEGER PRIMARY KEY AUTOINCREMENT,
+                       title TEXT, text TEXT)""")
+        txn.execute("""CREATE TABLE categories (id INTEGER PRIMARY KEY AUTOINCREMENT,
+                       name TEXT)""")
+        txn.execute("""CREATE TABLE posts_categories (category_id INTEGER, blogpost_id INTEGER)""")
         
     return Registry.DBPOOL.runInteraction(runInitTxn)
 

--- a/twistar/tests/test_relationships.py
+++ b/twistar/tests/test_relationships.py
@@ -320,6 +320,19 @@ class RelationshipTest(unittest.TestCase):
 
 
     @inlineCallbacks
+    def test_clear_jointable_on_delete_habtm_with_custom_args(self):
+        join_tablename = 'posts_categories'
+        post = yield Blogpost(title='headline').save()
+        category = yield Category(name="personal").save()
+
+        yield post.categories.set([category])
+        cat_id = category.id
+        yield category.delete()
+        res = yield self.config.select(join_tablename, where=['category_id = ?', cat_id], limit=1)
+        self.assertIsNone(res)
+
+
+    @inlineCallbacks
     def test_set_habtm_blank(self):
         user = yield User().save()
         color = yield FavoriteColor(name="red").save()

--- a/twistar/tests/utils.py
+++ b/twistar/tests/utils.py
@@ -22,6 +22,12 @@ class Avatar(DBObject):
 class FavoriteColor(DBObject):
     HABTM = ['users']    
 
+class Blogpost(DBObject):
+    HABTM = [dict(name='categories', join_table='posts_categories')]
+
+class Category(DBObject):
+    HABTM = [dict(name='blogposts', join_table='posts_categories')]
+
 class FakeObject(DBObject):
     pass
 
@@ -40,3 +46,5 @@ class Nickname(DBObject):
 
 Registry.register(Picture, User, Avatar, FakeObject, FavoriteColor)
 Registry.register(Boy, Girl, Nickname)
+Registry.register(Blogpost, Category)
+


### PR DESCRIPTION
hi brian,

when using the dict syntax to express a model's relationship like

``` python
class Blogpost(DBObject):
    HABTM = [dict(name='categories', join_table='posts_categories')]
```

an exception is raised on delete() calls:
getattr(): attribute name must be string

this is caused by the following code in the delete() method:

``` python
ds = [getattr(self, relation).clear(transaction=self._transaction) for relation in self.HABTM]
```

since in this case relation is a dictionary.

attached there's a small test to expose the problem and my proposed solution.

bye,
flavio
