### PR TITLE
fixed tests teardown for non-sqlite dbs

### DIFF
--- a/twistar/tests/mysql_config.py
+++ b/twistar/tests/mysql_config.py
@@ -41,5 +41,8 @@ def tearDownDB(self):
         txn.execute("DROP TABLE boys")
         txn.execute("DROP TABLE girls")
         txn.execute("DROP TABLE nicknames")
+        txn.execute("DROP TABLE blogposts")
+        txn.execute("DROP TABLE categories")
+        txn.execute("DROP TABLE posts_categories")
     return CONNECTION.runInteraction(runTearDownDB)
                 

--- a/twistar/tests/postgres_config.py
+++ b/twistar/tests/postgres_config.py
@@ -57,6 +57,14 @@ def tearDownDB(self):
 
         txn.execute("DROP SEQUENCE nicknames_id_seq CASCADE")
         txn.execute("DROP TABLE nicknames")
+
+        txn.execute("DROP SEQUENCE blogposts_id_seq CASCADE")
+        txn.execute("DROP TABLE blogposts")
+
+        txn.execute("DROP SEQUENCE categories_id_seq CASCADE")
+        txn.execute("DROP TABLE categories")
+
+        txn.execute("DROP TABLE posts_categories")
         
     return CONNECTION.runInteraction(runTearDownDB)
                 


### PR DESCRIPTION
hi brian,

in the last pull req. i forgot to update the teardown method in {mysql,postgres}_config.py (sorry!)

this should fix it, please check that everything is correct

thank you,
flavio
