### PR TITLE
Use inlineCallbacks in instead of DeferredList; fixes #35

### DIFF
--- a/twistar/tests/test_transactions.py
+++ b/twistar/tests/test_transactions.py
@@ -1,6 +1,6 @@
 from twisted.trial import unittest
 from twisted.enterprise import adbapi
-from twisted.internet.defer import inlineCallbacks, DeferredList
+from twisted.internet.defer import inlineCallbacks
 
 from twistar.exceptions import ReferenceNotSavedError
 from twistar.utils import transaction
@@ -23,11 +23,10 @@ class TransactionTest(unittest.TestCase):
     @inlineCallbacks
     def test_findOrCreate(self):
         @transaction
+        @inlineCallbacks
         def interaction(txn):
-            ds = []
-            ds.append(Transaction.findOrCreate(name="a name"))
-            ds.append(Transaction.findOrCreate(name="a name"))
-            return DeferredList(ds)
+            yield Transaction.findOrCreate(name="a name")
+            yield Transaction.findOrCreate(name="a name")
 
         yield interaction()
         count = yield Transaction.count()


### PR DESCRIPTION
I tried to understand it but could not figure out why this might have fixed the issue. I also tried adding `fireOnFirstErrback=True` and `fireOnFirstErrback=True, consumeErrors=True` to `DeferredList`, and also adding errbacks to everything, to no avail—nothing was printed and the issue persisted.

Unless you have a reason to believe using `inlineCallbacks` here is somehow bad or hides a/the real issue, this commit seems to have fixed it. The change also makes the test more readable (as `inlineCallbacks` always does).
