### PR TITLE
Fixes InteractionBase.insert() to return rowid as per source documentation

### DIFF
--- a/twistar/dbconfig/base.py
+++ b/twistar/dbconfig/base.py
@@ -182,7 +182,7 @@ class InteractionBase:
         q = "INSERT INTO %s %s %s" % (tablename, colnames, params)
         def _doinsert(txn, q, vals):
             self.executeTxn(txn, q, vals)
-            return txn.lastrowid
+            return self.getLastInsertID(txn)
         if not txn is None:
             return _doinsert(txn, q, vals.values())
         return self.runInteraction(_doinsert, q, vals.values())
@@ -224,10 +224,7 @@ class InteractionBase:
 
         @return: The integer id of the last inserted row.
         """
-        q = "SELECT LAST_INSERT_ID()"
-        self.executeTxn(txn, q)            
-        result = txn.fetchall()
-        return result[0][0]
+        return txn.lastrowid
     
 
     def delete(self, tablename, where=None):

--- a/twistar/dbconfig/base.py
+++ b/twistar/dbconfig/base.py
@@ -180,10 +180,12 @@ class InteractionBase:
             colnames = "(" + ",".join(ecolnames) + ")"
             params = "VALUES %s" % params
         q = "INSERT INTO %s %s %s" % (tablename, colnames, params)
+        def _doinsert(txn, q, vals):
+            self.executeTxn(txn, q, vals)
+            return txn.lastrowid
         if not txn is None:
-            return self.executeTxn(txn, q, vals.values())
-        return self.executeOperation(q, vals.values())
-
+            return _doinsert(txn, q, vals.values())
+        return self.runInteraction(_doinsert, q, vals.values())
 
     def escapeColNames(self, colnames):
         """

--- a/twistar/tests/test_utils.py
+++ b/twistar/tests/test_utils.py
@@ -65,13 +65,13 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(result, ["(one is ?)", None])
 
         result = utils.dictToWhere({ 'one': 'two', 'three': 'four' })
-        self.assertEqual(result, ["(three = ?) AND (one = ?)", "four", "two"])
+        self.assertEqual(result, ["(one = ?) AND (three = ?)", "two", "four"])
 
         result = utils.dictToWhere({ 'one': 'two', 'three': 'four', 'five': 'six' }, "BLAH")
-        self.assertEqual(result, ["(five = ?) BLAH (three = ?) BLAH (one = ?)", "six", "four", "two"])
+        self.assertEqual(result, ["(one = ?) BLAH (three = ?) BLAH (five = ?)", "two", "four", "six"])
 
         result = utils.dictToWhere({ 'one': 'two', 'three': None })
-        self.assertEqual(result, ["(three is ?) AND (one = ?)", None, "two"])
+        self.assertEqual(result, ["(one = ?) AND (three is ?)", "two", None])
 
 
     @inlineCallbacks

--- a/twistar/tests/test_utils.py
+++ b/twistar/tests/test_utils.py
@@ -7,6 +7,8 @@ from twistar.registry import Registry
 
 from utils import *
 
+from collections import OrderedDict
+
 class UtilsTest(unittest.TestCase):
     
     @inlineCallbacks
@@ -64,13 +66,16 @@ class UtilsTest(unittest.TestCase):
         result = utils.dictToWhere({ 'one': None }, "BLAH")
         self.assertEqual(result, ["(one is ?)", None])
 
-        result = utils.dictToWhere({ 'one': 'two', 'three': 'four' })
+        result = utils.dictToWhere(OrderedDict([
+            ('one', 'two'), ('three', 'four')]))
         self.assertEqual(result, ["(one = ?) AND (three = ?)", "two", "four"])
 
-        result = utils.dictToWhere({ 'one': 'two', 'three': 'four', 'five': 'six' }, "BLAH")
+        result = utils.dictToWhere(OrderedDict([
+            ('one', 'two'), ('three', 'four'), ('five', 'six')]), "BLAH")
         self.assertEqual(result, ["(one = ?) BLAH (three = ?) BLAH (five = ?)", "two", "four", "six"])
 
-        result = utils.dictToWhere({ 'one': 'two', 'three': None })
+        result = utils.dictToWhere(OrderedDict([
+            ('one', 'two'), ('three', None)]))
         self.assertEqual(result, ["(one = ?) AND (three is ?)", "two", None])
 
 


### PR DESCRIPTION
I've run into a use case where I need to manually insert and know the resulting rowid. It seems as though InteractionBase.insert() was meant to do this. I've done trivial test of the patch in my use case, and ensured that it passes all the unit tests.