### PR TITLE
Change getLastInsertID to use cursor.lastrowid from DB-API instead of hard coded query

### DIFF
--- a/twistar/dbconfig/base.py
+++ b/twistar/dbconfig/base.py
@@ -222,10 +222,7 @@ class InteractionBase:
 
         @return: The integer id of the last inserted row.
         """
-        q = "SELECT LAST_INSERT_ID()"
-        self.executeTxn(txn, q)            
-        result = txn.fetchall()
-        return result[0][0]
+        return txn.lastrowid
     
 
     def delete(self, tablename, where=None):


### PR DESCRIPTION
Perhaps a controversial change? It seems preferable to me to punt this to the DB-API layer for implementation/optimization. 

I don't think the SELECT hardcoded on the current implementation works on postgres (untested)... confusingly, this change may not help postgres support... but it doesn't break mysql nor sqlite.