### PR TITLE
Improve unit testing by means of Tox and Coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ _trial_temp
 build
 dist
 twistar.egg-info
+.tox
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,35 @@
 language: python
-python:
-  - "2.7"
-  - "pypy"
-install: pip install . pep8 pyflakes
-script: pep8 --ignore=E303 --max-line-length=140 ./twistar && find ./twistar -name '*.py' | xargs pyflakes && trial twistar
+sudo: false
+
+matrix:
+  include:
+    - env: TOXENV=py27-twisted12
+      python: "2.7"
+    - env: TOXENV=py27-twisted13
+      python: "2.7"
+    - env: TOXENV=py27-twisted14
+      python: "2.7"
+    - env: TOXENV=py27-twisted15
+      python: "2.7"
+    - env: TOXENV=py35-twisted15
+      python: "3.5"
+    - env: TOXENV=pypy-twisted12
+      python: "pypy"
+    - env: TOXENV=pypy-twisted13
+      python: "pypy"
+    - env: TOXENV=pypy-twisted14
+      python: "pypy"
+    - env: TOXENV=pypy-twisted15
+      python: "pypy"
+    - env: TOXENV=pypy3-twisted15
+      python: "pypy3"
+  allow_failures:
+    - env: TOXENV=py35-twisted15
+    - env: TOXENV=pypy3-twisted15
+
+install:
+    - pip install tox coveralls
+
+script: tox
+
+after_success: coveralls

--- a/README.markdown
+++ b/README.markdown
@@ -60,10 +60,11 @@ u = User.findBy(first_name="John", age=25).addCallback(found)
 This is a very simple example - see http://findingscience.com/twistar for more complicated examples and additional uses.
 
 ## Testing
-You will need to install the sqlite3 python package if you want to run the default tests.  To run the tests:
+To run unit-tests you simply require [Tox](https://tox.readthedocs.org)
 
+To run the tests:
 ```
-trial twistar
+tox
 ```
 
 By default, the tests are run with the database driver sqlite3.  To change this, set the DBTYPE environment variable:

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,5 @@
 # twistar: Asynchronous Python ORM
-[![Build Status](https://secure.travis-ci.org/bmuller/twistar.png?branch=master)](https://travis-ci.org/bmuller/twistar)
+[![Build Status](https://secure.travis-ci.org/bmuller/twistar.png?branch=master)](https://travis-ci.org/bmuller/twistar) [![Coverage Status](https://coveralls.io/repos/evilaliv3/twistar/badge.svg?branch=unittest)](https://coveralls.io/r/evilaliv3/twistar?branch=unittest)
 
 The Twistar Project provides an ActiveRecord (ORM) pattern interface to the Twisted Project's RDBMS library.  This file contains minimal documentation - see the project home page at http://findingscience.com/twistar for more information.
 

--- a/README.markdown
+++ b/README.markdown
@@ -75,7 +75,7 @@ DBTYPE=mysql trial twistar
 
 You'll need a database named "twistar" for each of those tests (or you can change the dbname, user, etc in the `<db type>_config.py` file in the tests folder).
 
-## Documenation
+## Documentation
 If you intent on generating API documentation, you will need pydoctor.  If you want to generate the user documentation, you will need to install Twisted Lore.
 
 To generate documentation:

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,5 @@
 # twistar: Asynchronous Python ORM
-[![Build Status](https://secure.travis-ci.org/bmuller/twistar.png?branch=master)](https://travis-ci.org/bmuller/twistar) [![Coverage Status](https://coveralls.io/repos/evilaliv3/twistar/badge.svg?branch=unittest)](https://coveralls.io/r/evilaliv3/twistar?branch=unittest)
+[![Build Status](https://secure.travis-ci.org/bmuller/twistar.png?branch=master)](https://travis-ci.org/bmuller/twistar) [![Coverage Status](https://coveralls.io/repos/bmuller/twistar/badge.svg?branch=master)](https://coveralls.io/r/bmuller/twistar?branch=master)
 
 The Twistar Project provides an ActiveRecord (ORM) pattern interface to the Twisted Project's RDBMS library.  This file contains minimal documentation - see the project home page at http://findingscience.com/twistar for more information.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,122 @@
+; tox configuration file for running tests similar to buildbot builders.
+
+[tox]
+envlist =
+    coverage
+    py26-twisted12
+    py26-twisted13
+    py26-twisted14
+    py26-twisted15
+    py27-twisted12
+    py27-twisted13
+    py27-twisted14
+    py27-twisted15
+    py35-twisted15
+    pypy-twisted12
+    pypy-twisted13
+    pypy-twisted14
+    pypy-twisted15
+    pypy3-twisted15
+
+[testenv]
+commands =
+    coverage erase
+    coverage run --source=./twistar {envbindir}/trial --rterrors {posargs:twistar}
+    coverage report -m
+
+[testenv:coveralls]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+deps =
+    coverage
+    coveralls
+    mock
+    twisted>=15.0, <16.0
+commands =
+    coverage erase
+    coverage run --source=./twistar {envbindir}/trial --rterrors {posargs:twistar}
+    coverage report -m
+    coveralls
+
+[testenv:py26-twisted12]
+deps =
+    coverage
+    mock
+    twisted>=12.0, <13.0
+
+[testenv:py26-twisted13]
+deps =
+    coverage
+    mock
+    twisted>=13.0, <14.0
+
+[testenv:py26-twisted14]
+deps =
+    coverage
+    mock
+    twisted>=14.0, <15.0
+
+[testenv:py26-twisted15]
+deps =
+    coverage
+    mock
+    twisted>=15.0, <15.5
+
+[testenv:py27-twisted12]
+deps =
+    coverage
+    mock
+    twisted>=12.0, <13.0
+
+[testenv:py27-twisted13]
+deps =
+    coverage
+    mock
+    twisted>=13.0, <14.0
+
+[testenv:py27-twisted14]
+deps =
+    coverage
+    mock
+    twisted>=14.0, <15.0
+
+[testenv:py27-twisted15]
+deps =
+    coverage
+    mock
+    twisted>=15.0, <16.0
+
+[testenv:py35-twisted15]
+deps =
+    coverage
+    mock
+    twisted>=15.0, <16.0
+
+[testenv:pypy-twisted12]
+deps =
+    coverage
+    mock
+    twisted>=12.0, <13.0
+
+[testenv:pypy-twisted13]
+deps =
+    coverage
+    mock
+    twisted>=13.0, <14.0
+
+[testenv:pypy-twisted14]
+deps =
+    coverage
+    mock
+    twisted>=14.0, <15.0
+
+[testenv:pypy-twisted15]
+deps =
+    coverage
+    mock
+    twisted>=15.0, <16.0
+
+[testenv:pypy3-twisted15]
+deps =
+    coverage
+    mock
+    twisted>=15.0, <16.0

--- a/tox.ini
+++ b/tox.ini
@@ -19,10 +19,11 @@ envlist =
     pypy3-twisted15
 
 [testenv]
+deps =
+    mock
+    twisted>=15.0, <16.0
 commands =
-    coverage erase
-    coverage run --source=./twistar {envbindir}/trial --rterrors {posargs:twistar}
-    coverage report -m
+    trial twistar
 
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
With this commit:
- test are now implemented using [Tox](https://tox.readthedocs.org/en/latest/)
- tests are now performed on all the relevant versions of twisted (12, 13, 14, 15)
- tests are now performed on all the relevant versions of python (2.7, 3.5, pypy, pypy3)
- code coverage is collected during tests and published on README.md and at https://coveralls.io/github/evilaliv3/twistar