### PR TITLE
Make type-checks 'future compatible' by using isinstance

### DIFF
--- a/twistar/dbconfig/base.py
+++ b/twistar/dbconfig/base.py
@@ -389,7 +389,7 @@ class InteractionBase(object):
 
         @return: A conditional in the same form as the C{where} parameter in L{DBObject.find}.
         """
-        assert(type(where) is list)
+        assert(isinstance(where, list))
         query = where[0].replace("?", "%s")
         args = where[1:]
         return (query, args)

--- a/twistar/dbconfig/pyodbc.py
+++ b/twistar/dbconfig/pyodbc.py
@@ -4,7 +4,7 @@ from twistar.dbconfig.base import InteractionBase
 class PyODBCDBConfig(InteractionBase):
 
     def whereToString(self, where):
-        assert(type(where) is list)
+        assert(isinstance(where, list))
         query = where[0]
         args = where[1:]
         return (query, args)

--- a/twistar/dbconfig/sqlite.py
+++ b/twistar/dbconfig/sqlite.py
@@ -4,7 +4,7 @@ from twistar.dbconfig.base import InteractionBase
 
 class SQLiteDBConfig(InteractionBase):
     def whereToString(self, where):
-        assert(type(where) is list)
+        assert(isinstance(where, list))
         query = where[0]
         args = where[1:]
         return (query, args)

--- a/twistar/dbobject.py
+++ b/twistar/dbobject.py
@@ -324,7 +324,7 @@ class DBObject(Validator):
         @param rtype: The relationship type.  It should be a key value from
         the C{TYPES} class variable in the class L{Relationship}.
         """
-        if type(relation) is dict:
+        if isinstance(relation, dict):
             if 'name' not in relation:
                 msg = "No key 'name' in the relation %s in class %s" % (relation, klass.__name__)
                 raise InvalidRelationshipError(msg)

--- a/twistar/utils.py
+++ b/twistar/utils.py
@@ -43,7 +43,7 @@ def createInstances(props, klass):
 
     @return: A C{Deferred} that will pass the result to a callback
     """
-    if type(props) is list:
+    if isinstance(props, list):
         ks = [klass(**prop) for prop in props]
         ds = [defer.maybeDeferred(k.afterInit) for k in ks]
         return defer.DeferredList(ds).addCallback(lambda _: ks)


### PR DESCRIPTION
Previously type-checks were done by doing
type(obj) is klass
This doesn't take into account 'future' libs that use object inheritance to
backport new features from 3 to 2 without breaking 2-only libs. Now type-checks
are done using 'isinstance', which is a more relaxed type-check, but also the
desired behavior typically.