### PR TITLE
Changes InteractionBase.select() to preserve where clause when id argument is provided

### DIFF
--- a/twistar/dbconfig/base.py
+++ b/twistar/dbconfig/base.py
@@ -106,7 +106,10 @@ class InteractionBase(object):
         select = select or "*"
 
         if id is not None:
-            where = ["id = ?", id]
+            if where is None:
+                where = ["id = ?", id]
+            else:
+                where = [" AND ".join([where[0], "id = ?"])] + where[1:] + [id]
             one = True
 
         if not isinstance(limit, tuple) and limit is not None and int(limit) == 1:

--- a/twistar/dbconfig/base.py
+++ b/twistar/dbconfig/base.py
@@ -7,7 +7,7 @@ from twisted.internet import defer
 
 from twistar.registry import Registry
 from twistar.exceptions import ImaginaryTableError, CannotRefreshError
-
+from twistar.utils import joinWheres
 
 class InteractionBase(object):
     """
@@ -109,7 +109,7 @@ class InteractionBase(object):
             if where is None:
                 where = ["id = ?", id]
             else:
-                where = [" AND ".join([where[0], "id = ?"])] + where[1:] + [id]
+                where = joinWheres(where, ["id = ?", id])
             one = True
 
         if not isinstance(limit, tuple) and limit is not None and int(limit) == 1:

--- a/twistar/tests/test_dbconfig.py
+++ b/twistar/tests/test_dbconfig.py
@@ -39,6 +39,18 @@ class DBConfigTest(unittest.TestCase):
 
 
     @inlineCallbacks
+    def test_select_id(self):
+        tablename = User.tablename()
+
+        result = yield self.dbconfig.select(tablename, self.user.id, where=None, limit=1, orderby="first_name ASC")
+        self.assertTrue(result is not None)
+
+        where = ['first_name = ?', "DNE"]
+        result = yield self.dbconfig.select(tablename, self.user.id, where=where, limit=1, orderby="first_name ASC")
+        self.assertTrue(result is None)
+
+
+    @inlineCallbacks
     def test_delete(self):
         tablename = User.tablename()
 


### PR DESCRIPTION
This works as expected when an id is not provided to
DBObject.find(where=...), but failed to work when using specifying an
id DBObject.find(id, where=...). InteractionBase.select() discards the
clause if an id is provided. This patch retains any provided where
clause.