### PR TITLE
fix log method with list object as argument instead of list of strings

### DIFF
--- a/twistar/dbconfig/base.py
+++ b/twistar/dbconfig/base.py
@@ -39,13 +39,12 @@ class InteractionBase(object):
             return
         log.msg("TWISTAR query: %s" % query)
         if len(args) > 0:
-            if isinstance(args[0], list):
+            if isinstance(args[0], list): # if args contains a list object
                 log.msg("TWISTAR args: %s" % ",".join(*args))
             else:
                 log.msg("TWISTAR args: %s" % ",".join(args))
         elif len(kwargs) > 0:
             log.msg("TWISTAR kargs: %s" % str(kwargs))
-
 
 
     def executeOperation(self, query, *args, **kwargs):

--- a/twistar/dbconfig/base.py
+++ b/twistar/dbconfig/base.py
@@ -39,7 +39,7 @@ class InteractionBase(object):
             return
         log.msg("TWISTAR query: %s" % query)
         if len(args) > 0:
-            if isinstance(args[0], list): # if args contains a list object
+            if isinstance(args[0], list):  # if args contains a list object
                 log.msg("TWISTAR args: %s" % ",".join(*args))
             else:
                 log.msg("TWISTAR args: %s" % ",".join(args))

--- a/twistar/dbconfig/base.py
+++ b/twistar/dbconfig/base.py
@@ -39,9 +39,13 @@ class InteractionBase(object):
             return
         log.msg("TWISTAR query: %s" % query)
         if len(args) > 0:
-            log.msg("TWISTAR args: %s" % ",".join(args))
+            if isinstance(args[0], list):
+                log.msg("TWISTAR args: %s" % ",".join(*args))
+            else:
+                log.msg("TWISTAR args: %s" % ",".join(args))
         elif len(kwargs) > 0:
             log.msg("TWISTAR kargs: %s" % str(kwargs))
+
 
 
     def executeOperation(self, query, *args, **kwargs):


### PR DESCRIPTION
if the log is passed a list of strings as `args`, it's okay, but if a list object is passed, then it can't do anything.

list object would be created by `whereToString` method in `base` class.